### PR TITLE
0.1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Plugin that allows the re-ordering of the navbar, sidebar, and tabs by dragging them into desired location within the UI.
 
+**Warning:** OctoPrint 1.4.1 isolated the gcode viewer into it's own plugin and as a result you may have to re-order that tab again after upgrading.
+
 **Note:** Plugin name is a play on words similar to `Drag and Drop` being misheard as `Dragon Drop`.
 
 ## Setup

--- a/octoprint_dragon_order/static/js/dragon_order.js
+++ b/octoprint_dragon_order/static/js/dragon_order.js
@@ -34,7 +34,12 @@ $(function() {
 					var new_tab_order = [];
 					$.each($('#tabs').sortable('toArray'), function(index, value){
 							if(value !== ''){
-								var new_value = value.replace('temp_link','temperature_link').replace('term_link','terminal_link').replace('gcode_link','gcodeviewer_link').replace(/^(tab_)?(.+)_link$/g,'$2');
+								var octo_version = VERSION.match(/\d+/gm);
+								if (octo_version[0] == 1 && octo_version[1] > 3 && octo_version[2] > 0){
+									var new_value = value.replace('temp_link','temperature_link').replace('term_link','terminal_link').replace('gcode_link','plugin_gcodeviewer_link').replace(/^(tab_)?(.+)_link$/g,'$2');
+								} else {
+									var new_value = value.replace('temp_link','temperature_link').replace('term_link','terminal_link').replace('gcode_link','gcodeviewer_link').replace(/^(tab_)?(.+)_link$/g,'$2');
+								}
 								new_tab_order.push(new_value);
 							}
 						});

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_dragon_order"
 plugin_name = "OctoPrint-DragonOrder"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.1.4"
+plugin_version = "0.1.5"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
- fix ordering of the gcode viewer tab in OctoPrint 1.4.1